### PR TITLE
Fix compatibility with everness mod hammer functionality

### DIFF
--- a/lib.lua
+++ b/lib.lua
@@ -118,7 +118,8 @@ function signs_bot.lib.is_simple_node(node)
 		if not ndef or node.name == "air" then return false end
 		if ndef.drop == "" then return false end
 		if ndef.diggable == false then return false end
-		if ndef.after_dig_node then return false end
+		-- Allow digging nodes with after_dig_node only when everness is loaded
+		if ndef.after_dig_node and not minetest.get_modpath("everness") then return false end
 	end
 	if type(ndef.drop) == "table" then
 		return handle_drop(ndef.drop)


### PR DESCRIPTION
Fix compatibility issue #48 where signs_bot refused to dig when everness mod was loaded.

The everness mod adds hammer functionality by hooking after_dig_node callbacks on all nodes, which caused signs_bot to consider these nodes as 'not simple' and refuse digging.

This fix only disables the after_dig_node check when everness is actually loaded, maintaining protection for Techage industrial plants and other valuable structures in non-everness setups.

Changes:
- Modified is_simple_node function in lib.lua to conditionally allow after_dig_node when everness is loaded
- Uses minetest.get_modpath('everness') to check if everness is present
- Preserves existing behavior for non-everness installations